### PR TITLE
Update sceNetAdhocctlDisconnect delay

### DIFF
--- a/Core/HLE/sceNetAdhoc.cpp
+++ b/Core/HLE/sceNetAdhoc.cpp
@@ -2472,7 +2472,7 @@ u32 NetAdhocctl_Disconnect() {
 	// Library initialized
 	if (netAdhocctlInited) {
 		int iResult, error;
-		hleEatMicro(1000);
+		hleEatMicro(16667);
 
 		if (isAdhocctlBusy && CoreTiming::IsScheduled(adhocctlNotifyEvent)) {
 			return ERROR_NET_ADHOCCTL_BUSY;


### PR DESCRIPTION
We might need at least 16ms (1 frame) delay here before the game calls the next Adhocctl syscall.